### PR TITLE
[000108-06] feat: implement SellerAvailableNearbyDTOResponse with filtered return of relevant data

### DIFF
--- a/src/main/java/com/ppm/delivery/seller/api/service/api/controller/ISellerController.java
+++ b/src/main/java/com/ppm/delivery/seller/api/service/api/controller/ISellerController.java
@@ -3,9 +3,9 @@ package com.ppm.delivery.seller.api.service.api.controller;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerDTORequest;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerNearSearchRequest;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerUpdateDTORequest;
+import com.ppm.delivery.seller.api.service.api.domain.response.SellerAvailableNearbyDTOResponse;
 import com.ppm.delivery.seller.api.service.api.domain.response.SellerDTOResponse;
 import com.ppm.delivery.seller.api.service.api.domain.response.SellerUpdateDTOResponse;
-import com.ppm.delivery.seller.api.service.domain.model.Seller;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,6 +24,6 @@ public interface ISellerController {
     ResponseEntity<SellerUpdateDTOResponse> patchV1(@Valid @PathVariable String code, @RequestBody SellerUpdateDTORequest sellerUpdateDTO);
 
     @PostMapping("/search-nearby")
-    ResponseEntity<List<Seller>> searchAvailableNearby(@Valid @RequestBody SellerNearSearchRequest request);
+    ResponseEntity<List<SellerAvailableNearbyDTOResponse>> searchAvailableNearby(@Valid @RequestBody SellerNearSearchRequest request);
 
 }

--- a/src/main/java/com/ppm/delivery/seller/api/service/api/controller/SellerController.java
+++ b/src/main/java/com/ppm/delivery/seller/api/service/api/controller/SellerController.java
@@ -3,14 +3,17 @@ package com.ppm.delivery.seller.api.service.api.controller;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerDTORequest;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerNearSearchRequest;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerUpdateDTORequest;
+import com.ppm.delivery.seller.api.service.api.domain.response.SellerAvailableNearbyDTOResponse;
 import com.ppm.delivery.seller.api.service.api.domain.response.SellerDTOResponse;
 import com.ppm.delivery.seller.api.service.api.domain.response.SellerUpdateDTOResponse;
-import com.ppm.delivery.seller.api.service.domain.model.Seller;
 import com.ppm.delivery.seller.api.service.service.ISellerService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -37,8 +40,8 @@ public class SellerController implements ISellerController{
     }
 
     @Override
-    public ResponseEntity<List<Seller>> searchAvailableNearby(@Valid @RequestBody SellerNearSearchRequest request) {
-        List<Seller> sellers = sellerService.searchAvailableNearby(request);
+    public ResponseEntity<List<SellerAvailableNearbyDTOResponse>> searchAvailableNearby(@Valid @RequestBody SellerNearSearchRequest request) {
+        List<SellerAvailableNearbyDTOResponse> sellers = sellerService.searchAvailableNearby(request);
 
         if (sellers.isEmpty()) {
             return ResponseEntity.noContent().build();

--- a/src/main/java/com/ppm/delivery/seller/api/service/api/domain/response/SellerAvailableNearbyDTOResponse.java
+++ b/src/main/java/com/ppm/delivery/seller/api/service/api/domain/response/SellerAvailableNearbyDTOResponse.java
@@ -1,0 +1,51 @@
+package com.ppm.delivery.seller.api.service.api.domain.response;
+
+import com.ppm.delivery.seller.api.service.domain.model.Address;
+import com.ppm.delivery.seller.api.service.domain.model.Identification;
+import com.ppm.delivery.seller.api.service.domain.model.enums.Status;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+public class SellerAvailableNearbyDTOResponse {
+
+    private String code;
+    private String countryCode;
+    private Identification identification;
+    private String name;
+    private String displayName;
+    private List<ContactDTO> contacts;
+    private Address address;
+    private Status status;
+    private List<BusinessHourDTO> businessHours;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @EqualsAndHashCode
+    public static class ContactDTO {
+        private String type;
+        private String value;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @EqualsAndHashCode
+    public static class BusinessHourDTO {
+        private String dayOfWeek;
+        private String openAt;
+        private String closeAt;
+    }
+
+}

--- a/src/main/java/com/ppm/delivery/seller/api/service/domain/mapper/SellerMapper.java
+++ b/src/main/java/com/ppm/delivery/seller/api/service/domain/mapper/SellerMapper.java
@@ -1,11 +1,14 @@
 package com.ppm.delivery.seller.api.service.domain.mapper;
 
-import com.ppm.delivery.seller.api.service.domain.model.Seller;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerDTORequest;
+import com.ppm.delivery.seller.api.service.api.domain.response.SellerAvailableNearbyDTOResponse;
+import com.ppm.delivery.seller.api.service.domain.model.Seller;
 import org.mapstruct.Mapper;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring",
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
@@ -15,5 +18,9 @@ public interface SellerMapper {
     SellerMapper INSTANCE = Mappers.getMapper(SellerMapper.class);
 
     Seller toEntity(SellerDTORequest sellerDTORequest);
+
+    SellerAvailableNearbyDTOResponse toSellerAvailableNearbyDTO(Seller seller);
+
+    List<SellerAvailableNearbyDTOResponse> toSellerAvailableNearbyDTOList(List<Seller> sellers);
 
 }

--- a/src/main/java/com/ppm/delivery/seller/api/service/service/ISellerService.java
+++ b/src/main/java/com/ppm/delivery/seller/api/service/service/ISellerService.java
@@ -3,6 +3,7 @@ package com.ppm.delivery.seller.api.service.service;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerDTORequest;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerNearSearchRequest;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerUpdateDTORequest;
+import com.ppm.delivery.seller.api.service.api.domain.response.SellerAvailableNearbyDTOResponse;
 import com.ppm.delivery.seller.api.service.api.domain.response.SellerDTOResponse;
 import com.ppm.delivery.seller.api.service.api.domain.response.SellerUpdateDTOResponse;
 import com.ppm.delivery.seller.api.service.domain.model.Seller;
@@ -13,6 +14,6 @@ public interface ISellerService {
 
     SellerDTOResponse create(SellerDTORequest sellerDTORequest);
     SellerUpdateDTOResponse update(String code, SellerUpdateDTORequest sellerUpdateDTORequest);
-    List<Seller> searchAvailableNearby(SellerNearSearchRequest request);
+    List<SellerAvailableNearbyDTOResponse> searchAvailableNearby(SellerNearSearchRequest request);
 
 }

--- a/src/main/java/com/ppm/delivery/seller/api/service/service/SellerService.java
+++ b/src/main/java/com/ppm/delivery/seller/api/service/service/SellerService.java
@@ -4,6 +4,7 @@ import com.ppm.delivery.seller.api.service.api.domain.request.BusinessHourDTOReq
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerDTORequest;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerNearSearchRequest;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerUpdateDTORequest;
+import com.ppm.delivery.seller.api.service.api.domain.response.SellerAvailableNearbyDTOResponse;
 import com.ppm.delivery.seller.api.service.api.domain.response.SellerDTOResponse;
 import com.ppm.delivery.seller.api.service.api.domain.response.SellerUpdateDTOResponse;
 import com.ppm.delivery.seller.api.service.api.interceptor.ContextHolder;
@@ -20,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,13 +33,15 @@ public class SellerService implements ISellerService {
     private final ContextHolder contextHolder;
     private final ISellerRepository sellerRepository;
     private final IPermissionService permissionService;
+    private final SellerMapper sellerMapper;
 
     public SellerService(final ContextHolder contextHolder,
                          final ISellerRepository sellerRepository,
-                         final IPermissionService permissionService) {
+                         final IPermissionService permissionService, SellerMapper sellerMapper) {
         this.contextHolder = contextHolder;
         this.sellerRepository = sellerRepository;
         this.permissionService = permissionService;
+        this.sellerMapper = sellerMapper;
     }
 
     @Override
@@ -78,7 +80,7 @@ public class SellerService implements ISellerService {
     }
 
     @Override
-    public List<Seller> searchAvailableNearby(SellerNearSearchRequest request) {
+    public List<SellerAvailableNearbyDTOResponse> searchAvailableNearby(SellerNearSearchRequest request) {
 
         final String countryCode = contextHolder.getCountry();
 
@@ -93,7 +95,7 @@ public class SellerService implements ISellerService {
                 dayOfWeek,
                 orderHours);
 
-        return sellers;
+        return sellerMapper.toSellerAvailableNearbyDTOList(sellers);
     }
 
     private void validateCreate(SellerDTORequest sellerDTORequest) {

--- a/src/test/java/com/ppm/delivery/seller/api/service/component/AbstractComponentTest.java
+++ b/src/test/java/com/ppm/delivery/seller/api/service/component/AbstractComponentTest.java
@@ -2,6 +2,7 @@ package com.ppm.delivery.seller.api.service.component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.ppm.delivery.seller.api.service.domain.mapper.SellerMapper;
 import com.ppm.delivery.seller.api.service.repository.ISellerRepository;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,9 @@ public abstract class AbstractComponentTest {
     protected MockMvc mockMvc;
 
     protected static ObjectMapper objectMapper;
+
+    @Autowired
+    protected SellerMapper sellerMapper;
 
     @BeforeAll
     public static void setUpOnce() {

--- a/src/test/java/com/ppm/delivery/seller/api/service/component/SellerGetAvailableComponentTest.java
+++ b/src/test/java/com/ppm/delivery/seller/api/service/component/SellerGetAvailableComponentTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.ppm.delivery.seller.api.service.PpmDeliverySellerApiServiceApplication;
 import com.ppm.delivery.seller.api.service.api.constants.HeaderConstants;
 import com.ppm.delivery.seller.api.service.api.domain.request.SellerNearSearchRequest;
+import com.ppm.delivery.seller.api.service.api.domain.response.SellerAvailableNearbyDTOResponse;
 import com.ppm.delivery.seller.api.service.builder.BusinessHourTestBuilder;
 import com.ppm.delivery.seller.api.service.builder.SellerBuilder;
 import com.ppm.delivery.seller.api.service.constants.ConstantsMocks;
@@ -21,13 +22,12 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 
 
 @AutoConfigureMockMvc
@@ -103,9 +103,9 @@ public class SellerGetAvailableComponentTest extends AbstractComponentTest {
                 .andExpect(status().isOk());
 
         //Assert
-        List<Seller> responseSellers = objectMapper.readValue(
+        List<SellerAvailableNearbyDTOResponse> responseSellers = objectMapper.readValue(
                 resultActions.andReturn().getResponse().getContentAsString(),
-                new TypeReference<List<Seller>>() {
+                new TypeReference<List<SellerAvailableNearbyDTOResponse>>() {
                 }
         );
 
@@ -113,12 +113,13 @@ public class SellerGetAvailableComponentTest extends AbstractComponentTest {
 
         assertFalse(responseSellers.isEmpty(), "The seller list must not be empty.");
         assertEquals(3, responseSellers.size(), "Should return only 3 active sellers that are nearby and open at the given time.");
-        assertThat(responseSellers, containsInAnyOrder(
-                sellerActiveInRangeOpenNow,
-                sellerActiveInRangeOpenNow2,
-                sellerSameLocationOpen
-        ));
 
+        List<SellerAvailableNearbyDTOResponse> expectedSellers = List.of(
+                sellerMapper.toSellerAvailableNearbyDTO(sellerActiveInRangeOpenNow),
+                sellerMapper.toSellerAvailableNearbyDTO(sellerActiveInRangeOpenNow2),
+                sellerMapper.toSellerAvailableNearbyDTO(sellerSameLocationOpen)
+        );
+        assertThat(responseSellers, containsInAnyOrder(expectedSellers.toArray()));
 
     }
 

--- a/src/test/java/com/ppm/delivery/seller/api/service/service/SellerServiceTest.java
+++ b/src/test/java/com/ppm/delivery/seller/api/service/service/SellerServiceTest.java
@@ -8,6 +8,8 @@ import com.ppm.delivery.seller.api.service.api.domain.response.SellerUpdateDTORe
 import com.ppm.delivery.seller.api.service.api.interceptor.ContextHolder;
 import com.ppm.delivery.seller.api.service.builder.SellerBuilder;
 import com.ppm.delivery.seller.api.service.builder.SellerDTORequestBuilder;
+import com.ppm.delivery.seller.api.service.constants.ConstantsMocks;
+import com.ppm.delivery.seller.api.service.domain.mapper.SellerMapper;
 import com.ppm.delivery.seller.api.service.domain.model.BusinessHour;
 import com.ppm.delivery.seller.api.service.domain.model.Seller;
 import com.ppm.delivery.seller.api.service.domain.model.enums.Status;
@@ -16,7 +18,6 @@ import com.ppm.delivery.seller.api.service.exception.BusinessException;
 import com.ppm.delivery.seller.api.service.exception.EntityNotFoundException;
 import com.ppm.delivery.seller.api.service.exception.MessageErrorConstants;
 import com.ppm.delivery.seller.api.service.repository.ISellerRepository;
-import com.ppm.delivery.seller.api.service.constants.ConstantsMocks;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,15 +40,20 @@ public class SellerServiceTest {
 
     @InjectMocks
     private SellerService sellerService;
+
     @Mock
     private ISellerRepository sellerRepository;
+
     @Mock
     private ContextHolder contextHolder;
 
+    @Mock
+    private SellerMapper sellerMapper;
+
     @BeforeEach
     void setUp() {
-        PermissionService permissionValidator = new PermissionService(contextHolder);
-        sellerService = new SellerService(contextHolder, sellerRepository, permissionValidator);
+        PermissionService permissionValidator = new PermissionService(contextHolder); // cria com o mock contextHolder
+        sellerService = new SellerService(contextHolder, sellerRepository, permissionValidator, sellerMapper);
     }
 
     @Test


### PR DESCRIPTION
Esta PR implementa um novo DTO para representar os sellers disponíveis próximos, atendendo à mudança de requisito que exige a exclusão de campos sensíveis como audit, creatorId, id, etc.

**Principais alterações:**

1. Criado SellerAvailableNearbyDTOResponse, com classes internas ContactDTO e BusinessHourDTO
2. Remoção de campos:
    - Seller: audit, creatorId
    - BusinessHour e Contact: id, audit

3. Atualização do SellerMapper com métodos:
    - toSellerAvailableNearbyDTO(Seller seller)

    - toSellerAvailableNearbyDTOList(List<Seller> sellers)

4. Alteração do método searchAvailableNearby no serviço para usar o novo DTO
5. Atualização no controller e nos testes para refletir as mudanças

**Motivação:**
Padronizar e simplificar o payload retornado ao cliente com apenas os dados relevantes para a funcionalidade de busca de sellers próximos.