### PR TITLE
[000108-07] test(service): cover searchAvailableNearby with list and empty scenarios, using builders and assertAll

### DIFF
--- a/src/main/java/com/ppm/delivery/seller/api/service/api/domain/response/SellerAvailableNearbyDTOResponse.java
+++ b/src/main/java/com/ppm/delivery/seller/api/service/api/domain/response/SellerAvailableNearbyDTOResponse.java
@@ -1,6 +1,6 @@
 package com.ppm.delivery.seller.api.service.api.domain.response;
 
-import com.ppm.delivery.seller.api.service.domain.model.Address;
+import com.ppm.delivery.seller.api.service.api.domain.request.AddressDTORequest;
 import com.ppm.delivery.seller.api.service.domain.model.Identification;
 import com.ppm.delivery.seller.api.service.domain.model.enums.Status;
 import lombok.*;
@@ -21,7 +21,7 @@ public class SellerAvailableNearbyDTOResponse {
     private String name;
     private String displayName;
     private List<ContactDTO> contacts;
-    private Address address;
+    private AddressDTORequest address;
     private Status status;
     private List<BusinessHourDTO> businessHours;
 

--- a/src/main/java/com/ppm/delivery/seller/api/service/service/SellerService.java
+++ b/src/main/java/com/ppm/delivery/seller/api/service/service/SellerService.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 public class SellerService implements ISellerService {

--- a/src/test/java/com/ppm/delivery/seller/api/service/builder/SellerAvailableNearbyDTOResponseBuilder.java
+++ b/src/test/java/com/ppm/delivery/seller/api/service/builder/SellerAvailableNearbyDTOResponseBuilder.java
@@ -1,0 +1,55 @@
+package com.ppm.delivery.seller.api.service.builder;
+
+import com.ppm.delivery.seller.api.service.api.domain.request.AddressDTORequest;
+import com.ppm.delivery.seller.api.service.api.domain.request.GeoCoordinatesDTORequest;
+import com.ppm.delivery.seller.api.service.api.domain.request.LocationDTORequest;
+import com.ppm.delivery.seller.api.service.api.domain.response.SellerAvailableNearbyDTOResponse;
+import com.ppm.delivery.seller.api.service.domain.model.Identification;
+import com.ppm.delivery.seller.api.service.domain.model.Seller;
+
+import java.util.stream.Collectors;
+
+public class SellerAvailableNearbyDTOResponseBuilder {
+
+    public static SellerAvailableNearbyDTOResponse createDefault(Seller seller) {
+
+        return new SellerAvailableNearbyDTOResponse(
+                seller.getCode(),
+                seller.getCountryCode(),
+                new Identification(
+                        seller.getIdentification().getType(),
+                        seller.getIdentification().getCode()
+                ),
+                seller.getName(),
+                seller.getDisplayName(),
+                seller.getContacts().stream()
+                        .map(c -> new SellerAvailableNearbyDTOResponse.ContactDTO(
+                                c.getType(),
+                                c.getValue()
+                        ))
+                        .collect(Collectors.toList()),
+                new AddressDTORequest(
+                        new LocationDTORequest(
+                                new GeoCoordinatesDTORequest(
+                                        seller.getAddress().getLocation().getGeoCoordinates().getLatitude(),
+                                        seller.getAddress().getLocation().getGeoCoordinates().getLongitude()
+                                ),
+                                seller.getAddress().getLocation().getCity(),
+                                seller.getAddress().getLocation().getCountry(),
+                                seller.getAddress().getLocation().getState(),
+                                seller.getAddress().getLocation().getNumber(),
+                                seller.getAddress().getLocation().getZipCode(),
+                                seller.getAddress().getLocation().getStreetAddress()
+                        )
+                ),
+                seller.getStatus(),
+                seller.getBusinessHours().stream()
+                        .map(b -> new SellerAvailableNearbyDTOResponse.BusinessHourDTO(
+                                b.getDayOfWeek(),
+                                b.getOpenAt(),
+                                b.getCloseAt()
+                        ))
+                        .collect(Collectors.toList())
+        );
+    }
+}


### PR DESCRIPTION
- Adiciona testes unitários ao SellerService para o método searchAvailableNearby.

- Cobre cenários de retorno de múltiplos sellers e de lista vazia.

- Utiliza SellerAvailableNearbyDTOResponseBuilder para criar DTOs realistas a partir de entidades Seller.

- Valida interações com ContextHolder, SellerRepository e SellerMapper.

- Melhora a confiabilidade do serviço, garantindo mapeamento correto e tratamento de ausência de dados.